### PR TITLE
Allow dynamic input of the version with wrapper action for easier testing

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -2,7 +2,11 @@ name: "Example of full release data"
 
 on:
   workflow_dispatch:
-
+    inputs:
+      use-version:
+        description: "Release version"
+        required: true
+        default: "v2"
 
 jobs:
   get-release-notes:
@@ -19,9 +23,10 @@ jobs:
       
       - name: Get "${{ github.repository }}" Release notes
         id: release_data
-        uses: KevinRohn/github-full-release-data@v2
-        with: 
-          body-markdown-file-path: ${{ steps.output_file.outputs.notes }}
+        uses: jenseng/dynamic-uses@v1
+        with:
+          uses: KevinRohn/github-full-release-data@${{ github.event.inputs.use-version }}
+          with: '{ "body-markdown-file-path" : ${{ steps.output_file.outputs.notes }} }'
 
       - name: Upload downloaded release-note as Workflow artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION

* [`.github/workflows/example.yml`](diffhunk://#diff-d6ed008bccc277977568760d40099e6ddfdc2e8d47874752724c33f2676588e3L5-R9): Added input parameters to specify the release version dynamically (`use-version`).
* [`.github/workflows/example.yml`](diffhunk://#diff-d6ed008bccc277977568760d40099e6ddfdc2e8d47874752724c33f2676588e3L22-R29): Updated the action used to fetch release data to use a dynamic version based on the input parameter.